### PR TITLE
Render arrays and maps, +cosmetic, +readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,14 @@
 
 An online decoder for [COSE](https://datatracker.ietf.org/doc/html/rfc8152) messages, currently limited to COSE_Sign1.
 
+## Live preview
+
 https://gluecose.github.io/cose-viewer/
+
+## Development
+
+1. Install [`npm`](https://nodejs.org/en/download)
+2. Install project dependencies `npm install`
+3. Run a build script `npm run build`, the files will appear in `dist` directory
+4. Serve built files locally and access them via your browser, e.g. `python3 -m http.server 8080 --bind 127.0.0.1 --directory dist`
+

--- a/dist/index.html
+++ b/dist/index.html
@@ -21,14 +21,30 @@
         #output {
             width: 100%;
         }
+        .header {
+            width: 80%;
+            margin: 0 auto;
+            text-align: center;
+        }
+        .footer {
+            width: 80%;
+            margin: 50px auto;
+            text-align: right;
+        }
     </style>
 </head>
 <body>
+    <div class="header">
+        <h1>COSE Viewer</h1>
+    </div>
     <div id="container">
         Note: This tool supports COSE_Sign1 only.<br /><br />
         <input type="file" id="file" /> <button id="load-file">Load File</button>
         <button id="load-hex">Load from Hex</button><br />
         <pre id="output"></pre>
+    </div>
+    <div class="footer">
+        <p>Source code @ <a href="https://github.com/gluecose/cose-viewer">GitHub</a></p>
     </div>
 
     <script src="main.js"></script>


### PR DESCRIPTION
Issues:

- Map structures do not render at the moment, e.g. CWT_claims header with (label: 15)

<img width="331" alt="empty-header-value-rendered" src="https://github.com/user-attachments/assets/842e170d-d8b9-4d14-9460-43a8346b775d">

- Arrays do not render and appear empty, e.g. a CBOR array

<img width="339" alt="array-does-not-render" src="https://github.com/user-attachments/assets/8c58d20e-927b-421f-a77e-300ffa3bbfe2">

Additions:

- Expanded `prettyUnknown()` to understand what to do with a "Map" or and "Array"
- Switched countersignature renderer to use `prettyUnknown()`
- Added CWT claims header mapping to label 15
- Checked to see if renders as expected with an example envelope locally (see screenshot below)
- Cosmetics: added the header to HTML
- Cosmetics: added the footer with a link that points to this repo
- Readme: added instructions how to work with it locally

![render-preview-after-changes](https://github.com/user-attachments/assets/2fcc22f3-29fb-46e8-acc4-49b9a9aee35e)
